### PR TITLE
docs: add bugfix, chore, and docs branch types (#17)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,15 @@ feature/<issue-number>-<short-description>
 
 Example: `feature/123-add-login-page`
 
+### Bugfix branches
+
+```
+bugfix/<issue-number>-<short-description>
+```
+
+Example: `bugfix/456-compression-handling`
+
+
 ### Hotfix branches
 
 ```
@@ -19,6 +28,22 @@ hotfix/<short-description>
 ```
 
 Example: `hotfix/fix-login-bug`
+
+### Chore branches
+
+```
+chore/<issue-number>-<short-description>
+```
+
+Example: `docs/123-update-building-workflow`
+
+### Documentation branches
+
+```
+docs/<issue-number>-<short-description>
+```
+
+Example: `docs/17-update-branch-naming-scheme`
 
 ### Release branches
 


### PR DESCRIPTION
Added a few more branch naming schema rules, with types: `bugfix`, `chore` and `docs`.

Closes #17 