### PR TITLE
refactor(backend): rename package name to match new org repo (#46)

### DIFF
--- a/backend/cmd/labstore-server/main.go
+++ b/backend/cmd/labstore-server/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/DataLabTechTV/labstore/backend/internal/helper"
+import "github.com/IllumiKnowLabs/labstore/backend/internal/helper"
 
 func main() {
 	rootCmd := NewRootCmd()

--- a/backend/cmd/labstore-server/root.go
+++ b/backend/cmd/labstore-server/root.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/config"
-	"github.com/DataLabTechTV/labstore/backend/internal/helper"
-	"github.com/DataLabTechTV/labstore/backend/pkg/constants"
-	"github.com/DataLabTechTV/labstore/backend/pkg/iam"
-	"github.com/DataLabTechTV/labstore/backend/pkg/logger"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/config"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/helper"
+	"github.com/IllumiKnowLabs/labstore/backend/pkg/constants"
+	"github.com/IllumiKnowLabs/labstore/backend/pkg/iam"
+	"github.com/IllumiKnowLabs/labstore/backend/pkg/logger"
 	"github.com/spf13/cobra"
 )
 

--- a/backend/cmd/labstore-server/serve.go
+++ b/backend/cmd/labstore-server/serve.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/DataLabTechTV/labstore/backend/internal/router"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/router"
 	"github.com/spf13/cobra"
 )
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,4 +1,4 @@
-module github.com/DataLabTechTV/labstore/backend
+module github.com/IllumiKnowLabs/labstore/backend
 
 go 1.25.4
 

--- a/backend/internal/auth/signature.go
+++ b/backend/internal/auth/signature.go
@@ -14,8 +14,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/security"
-	"github.com/DataLabTechTV/labstore/backend/pkg/iam"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/security"
+	"github.com/IllumiKnowLabs/labstore/backend/pkg/iam"
 )
 
 type sigV4Request struct {

--- a/backend/internal/auth/streaming.go
+++ b/backend/internal/auth/streaming.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/security"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/security"
 )
 
 type sigV4ChunkedReader struct {

--- a/backend/internal/bucket/create_bucket.go
+++ b/backend/internal/bucket/create_bucket.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/config"
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/config"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
 )
 
 func ErrorBucketAlreadyExists() *core.S3Error {

--- a/backend/internal/bucket/delete_bucket.go
+++ b/backend/internal/bucket/delete_bucket.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/config"
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/config"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
 )
 
 func DeleteBucket(bucket string) error {

--- a/backend/internal/bucket/list_objects.go
+++ b/backend/internal/bucket/list_objects.go
@@ -16,9 +16,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/config"
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
-	"github.com/DataLabTechTV/labstore/backend/internal/middleware"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/config"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/middleware"
 )
 
 const DefaultMaxKeys = 250

--- a/backend/internal/config/env.go
+++ b/backend/internal/config/env.go
@@ -8,9 +8,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/helper"
-	"github.com/DataLabTechTV/labstore/backend/internal/security"
-	"github.com/DataLabTechTV/labstore/backend/pkg/constants"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/helper"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/security"
+	"github.com/IllumiKnowLabs/labstore/backend/pkg/constants"
 	"github.com/caarlos0/env/v11"
 	"github.com/joho/godotenv"
 )

--- a/backend/internal/core/util.go
+++ b/backend/internal/core/util.go
@@ -3,8 +3,8 @@ package core
 import (
 	"path/filepath"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/config"
-	"github.com/DataLabTechTV/labstore/backend/internal/helper"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/config"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/helper"
 )
 
 func BucketExists(bucket string) bool {

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/auth"
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/auth"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
 )
 
 const accessKeyCtx ContextKey = "accessKey"

--- a/backend/internal/middleware/iam.go
+++ b/backend/internal/middleware/iam.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
-	"github.com/DataLabTechTV/labstore/backend/pkg/iam"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/pkg/iam"
 )
 
 const iamActionCtx ContextKey = "iamAction"

--- a/backend/internal/object/delete_object.go
+++ b/backend/internal/object/delete_object.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/config"
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/config"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
 )
 
 func DeleteObject(bucket, key string) error {

--- a/backend/internal/object/delete_objects.go
+++ b/backend/internal/object/delete_objects.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/config"
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/config"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
 )
 
 type DeleteObjectsRequest struct {

--- a/backend/internal/object/error.go
+++ b/backend/internal/object/error.go
@@ -3,7 +3,7 @@ package object
 import (
 	"net/http"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
 )
 
 func ErrorNoSuchKey(key string) *core.S3Error {

--- a/backend/internal/object/get_object.go
+++ b/backend/internal/object/get_object.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/config"
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/config"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
 )
 
 type GetObjectResult struct {

--- a/backend/internal/object/head_object.go
+++ b/backend/internal/object/head_object.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
-	"github.com/DataLabTechTV/labstore/backend/internal/helper"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/helper"
 )
 
 // HeadObjectHandler: Head /:bucket/:key

--- a/backend/internal/object/put_object.go
+++ b/backend/internal/object/put_object.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/config"
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/config"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
 )
 
 func PutObject(bucket string, key string, data []byte) error {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -7,12 +7,12 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/bucket"
-	"github.com/DataLabTechTV/labstore/backend/internal/config"
-	"github.com/DataLabTechTV/labstore/backend/internal/middleware"
-	"github.com/DataLabTechTV/labstore/backend/internal/object"
-	"github.com/DataLabTechTV/labstore/backend/internal/service"
-	"github.com/DataLabTechTV/labstore/backend/pkg/iam"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/bucket"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/config"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/middleware"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/object"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/service"
+	"github.com/IllumiKnowLabs/labstore/backend/pkg/iam"
 )
 
 func Start() {

--- a/backend/internal/security/security.go
+++ b/backend/internal/security/security.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/DataLabTechTV/labstore/backend/pkg/constants"
+	"github.com/IllumiKnowLabs/labstore/backend/pkg/constants"
 )
 
 const Redacted = "**REDACTED**"

--- a/backend/internal/service/list_buckets.go
+++ b/backend/internal/service/list_buckets.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/DataLabTechTV/labstore/backend/internal/config"
-	"github.com/DataLabTechTV/labstore/backend/internal/core"
-	"github.com/DataLabTechTV/labstore/backend/internal/middleware"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/config"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/core"
+	"github.com/IllumiKnowLabs/labstore/backend/internal/middleware"
 )
 
 // !FIXME: move types to a proper location

--- a/backend/pkg/iam/iam.go
+++ b/backend/pkg/iam/iam.go
@@ -1,6 +1,6 @@
 package iam
 
-import "github.com/DataLabTechTV/labstore/backend/internal/config"
+import "github.com/IllumiKnowLabs/labstore/backend/internal/config"
 
 var Users map[string]string
 var Policies map[string]PolicyFunc


### PR DESCRIPTION
Renamed backend module to match the new `IllumiKnowLabs/labstore` repo, which was previously `DataLabTechTV/labstore` .

Closes #46 