### PR TITLE
Setup `golangci-lint`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: lint
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
- Update `justfile` to check for linters and `pre-commit`, as well as to install git hooks
- Configure Go linting for backend
- Fix backend Go code to respect linter
- Setup GHA for linting using `pre-commit` (runs on push or for PRs to `main` or `release/*`)