### PR TITLE
refactor(backend): replace TrimRight wiht TrimSuffix for correctness

### DIFF
--- a/backend/internal/middleware/normalize.go
+++ b/backend/internal/middleware/normalize.go
@@ -8,7 +8,7 @@ import (
 func NormalizeMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
-			r.URL.Path = strings.TrimRight(r.URL.Path, "/")
+			r.URL.Path = strings.TrimSuffix(r.URL.Path, "/")
 		}
 		next.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
Using `http.StripPrefix` didn't really apply here, as we need to strip a suffix, not a prefix.

We simply adjust `strings.TrimRight`, using `strings.TrimSuffix` instead. We change nothing else. The alternative is to use `gorilla/mux` instead, but this simple case doesn't justify adding a dependency just yet.

Closes #52 