### PR TITLE
feat(backend): add support for configurable buffered PutObject requests

### DIFF
--- a/backend/cmd/labstore-server/serve.go
+++ b/backend/cmd/labstore-server/serve.go
@@ -27,6 +27,7 @@ func NewServeCmd() *cobra.Command {
 	cmd.Flags().String("storage-path", config.DefaultStoragePath, "Storage path for objects and internals")
 	cmd.Flags().String("admin-user", config.DefaultAdminAccessKey, "Admin username / access key")
 	cmd.Flags().String("admin-pass", config.DefaultAdminSecretKey, "Admin password / secret key")
+	cmd.Flags().Int("perf-buffer-size", config.DefaultPerfBufferSize, "Performance setting for buffer size in bytes")
 
 	return cmd
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -21,6 +21,7 @@ const DefaultPort = 6789
 const DefaultStoragePath = "./data"
 const DefaultAdminAccessKey = "admin"
 const DefaultAdminSecretKey = DefaultAdminAccessKey
+const DefaultPerfBufferSize = 256 * helper.KiB
 
 var Config AppConfig
 
@@ -29,10 +30,11 @@ type AppConfig struct {
 }
 
 type ServerConfig struct {
-	Host    string        `mapstructure:"host"`
-	Port    uint16        `mapstructure:"port"`
-	Storage StorageConfig `mapstructure:"storage"`
-	Admin   AdminConfig   `mapstructure:"admin"`
+	Host        string            `mapstructure:"host"`
+	Port        uint16            `mapstructure:"port"`
+	Storage     StorageConfig     `mapstructure:"storage"`
+	Admin       AdminConfig       `mapstructure:"admin"`
+	Performance PerformanceConfig `mapstructure:"performance"`
 }
 
 type StorageConfig struct {
@@ -44,11 +46,16 @@ type AdminConfig struct {
 	SecretKey string `mapstructure:"secret_key"`
 }
 
+type PerformanceConfig struct {
+	BufferSize int `mapstructure:"buffer_size"`
+}
+
 func (config *ServerConfig) Debug() {
 	slog.Debug("config set", "name", "server.host", "value", config.Host)
 	slog.Debug("config set", "name", "server.port", "value", config.Port)
 	slog.Debug("config set", "name", "server.storage.path", "value", config.Storage.Path)
 	slog.Debug("config set", "name", "server.admin.access_key", "value", config.Admin.AccessKey)
+	slog.Debug("config set", "name", "server.performance.buffer_size", "value", config.Performance.BufferSize)
 
 	var adminSecretKeyDisplay string
 	if len(config.Admin.SecretKey) > 0 {
@@ -102,6 +109,8 @@ func setDefaults() {
 
 	viper.SetDefault("server.admin.secret_key", defaultAdminSecretKey)
 	fmt.Printf("🔑 Default admin secret key: %s\n", defaultAdminSecretKey)
+
+	viper.SetDefault("server.performance.buffer_size", DefaultPerfBufferSize)
 }
 
 func setOverrides(rootCmd *cobra.Command) {

--- a/backend/internal/object/put_object.go
+++ b/backend/internal/object/put_object.go
@@ -1,7 +1,7 @@
 package object
 
 import (
-	"bytes"
+	"bufio"
 	"io"
 	"net/http"
 	"os"
@@ -12,7 +12,7 @@ import (
 	"github.com/IllumiKnowLabs/labstore/backend/internal/helper"
 )
 
-func PutObject(bucket string, key string, data []byte) error {
+func PutObject(bucket string, key string, reader io.Reader) error {
 	bucketPath := filepath.Join(config.Config.Server.Storage.Path, bucket)
 	if _, err := os.Stat(bucketPath); os.IsNotExist(err) {
 		return core.ErrNoSuchBucket(bucket)
@@ -30,7 +30,9 @@ func PutObject(bucket string, key string, data []byte) error {
 	}
 	defer helper.CloseWithErr(f, &err)
 
-	_, err = io.Copy(f, bytes.NewReader(data))
+	writer := bufio.NewWriterSize(f, config.Config.Server.Performance.BufferSize)
+
+	_, err = io.CopyBuffer(writer, reader, make([]byte, config.Config.Server.Performance.BufferSize))
 	if err != nil {
 		return core.ErrInternalError("Failed to write object")
 	}
@@ -43,13 +45,7 @@ func PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 	bucket := r.PathValue("bucket")
 	key := r.PathValue("key")
 
-	data, err := io.ReadAll(r.Body)
-	if err != nil {
-		core.HandleError(w, err)
-		return
-	}
-
-	if err := PutObject(bucket, key, data); err != nil {
+	if err := PutObject(bucket, key, r.Body); err != nil {
 		core.HandleError(w, err)
 		return
 	}

--- a/labstore.example.yml
+++ b/labstore.example.yml
@@ -6,6 +6,8 @@ server:
   admin:
     access_key: admin
     secret_key: adminadmin
+  performance:
+    buffer_size: 262144
 
 web:
   host: 0.0.0.0


### PR DESCRIPTION
This adds buffered `PutObject` requests. Previously objects were completely loaded into memory before being written to disk unbuffered. This could result in OOM for large objects (or multiple uploads or medium sized objects), when reading the full object to memory. On the other hand, we were using `io.Copy`, which defaults to a buffer of 32 KiB—our default is now 256 KiB. So, not only did we protect our code from OOM, we also increased the write speed and the overall efficiency of `PutObject`.