### PR TITLE
fix(backend): banner border disabled when a real terminal is not detected

### DIFF
--- a/backend/cmd/labstore-server/root.go
+++ b/backend/cmd/labstore-server/root.go
@@ -20,7 +20,12 @@ func NewRootCmd() *cobra.Command {
 		Long:  fmt.Sprintf("%s - %s, by %s", constants.Name, constants.Description, constants.Author),
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			helper.Box(fmt.Sprintf("🚀 Welcome to %s, by %s", constants.Name, constants.Author))
+			welcomeMsg := fmt.Sprintf("🚀 Welcome to %s, by %s", constants.Name, constants.Author)
+			if helper.SupportsBox() {
+				helper.Box(welcomeMsg)
+			} else {
+				fmt.Println(welcomeMsg)
+			}
 
 			debug := helper.Must(cmd.Flags().GetBool("debug"))
 			logger.Init(logger.WithDebugFlag(debug))

--- a/backend/internal/helper/tui.go
+++ b/backend/internal/helper/tui.go
@@ -2,8 +2,15 @@ package helper
 
 import (
 	"fmt"
+	"os"
 	"strings"
+
+	"github.com/mattn/go-isatty"
 )
+
+func SupportsBox() bool {
+	return isatty.IsTerminal(os.Stdout.Fd())
+}
 
 func RuneDisplayWidth(r rune) int {
 	if r <= 0x1FFF {


### PR DESCRIPTION
We just disabled the border when stdout is not detected as a terminal, via `isatty`.

Closes #80 